### PR TITLE
Launch file for webtools in strands

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+
+    <!-- The default styling is provided by http://getbootstrap.com -->
+    <link href="css/bootstrap.css" rel="stylesheet">
+    <link href="css/main.css" rel="stylesheet">
+    
+    <link rel="stylesheet" type="text/css" href="css/jquery-ui.css" />
+  </head>
+  <body>
+   <div class="container">
+      <h1><small>STRANDS Remote Control</small></h1>
+      <ul>
+        <li><a href="main.html">Teleoperation</a></li>
+        <li><a href="map.html">Map Interaction</a></li>
+      </ul>
+    
+    </div>
+
+  </body>
+</html>

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,0 +1,9 @@
+<package>
+    <description brief="strands_webtools">
+      Remote control out robots via a browser
+    </description>
+    <author>Nick Hawes, Marc Hanheide, Lars Kunze</author>
+    <license>BSD</license>
+    <review status="unreviewed" notes=""/>
+    <url>http://www.strands-project.eu</url>
+</package>

--- a/webserver.sh
+++ b/webserver.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python -m SimpleHTTPServer

--- a/webtools.launch
+++ b/webtools.launch
@@ -1,0 +1,5 @@
+<launch>
+	<include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" />
+	<node pkg="strands_webtools" type="webserver.sh" name="webserver" cwd="node" />
+	<node pkg="mjpeg_server" type="mjpeg_server" name="mjpeg_server" />
+</launch>


### PR DESCRIPTION
fixed #4

now launches mjpg_server, rosbridge, and SimpleHTTPServer in one file. 
